### PR TITLE
Minor Python 2 to Python 3 changes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # mir_eval documentation build configuration file, created by
 # sphinx-quickstart on Thu May  8 15:55:45 2014.

--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -303,19 +303,19 @@ def quality_to_bitmap(quality):
 # TODO(ejhumphrey): Revisit how minmaj7's are mapped. This is how TMC did it,
 #   but MMV handles it like a separate quality (rather than an add7).
 EXTENDED_QUALITY_REDUX = {
-    "minmaj7": ("min", set(["7"])),
-    "maj9": ("maj7", set(["9"])),
-    "min9": ("min7", set(["9"])),
-    "9": ("7", set(["9"])),
-    "b9": ("7", set(["b9"])),
-    "#9": ("7", set(["#9"])),
-    "11": ("7", set(["9", "11"])),
-    "#11": ("7", set(["9", "#11"])),
-    "13": ("7", set(["9", "11", "13"])),
-    "b13": ("7", set(["9", "11", "b13"])),
-    "min11": ("min7", set(["9", "11"])),
-    "maj13": ("maj7", set(["9", "11", "13"])),
-    "min13": ("min7", set(["9", "11", "13"])),
+    "minmaj7": ("min", {"7"}),
+    "maj9": ("maj7", {"9"}),
+    "min9": ("min7", {"9"}),
+    "9": ("7", {"9"}),
+    "b9": ("7", {"b9"}),
+    "#9": ("7", {"#9"}),
+    "11": ("7", {"9", "11"}),
+    "#11": ("7", {"9", "#11"}),
+    "13": ("7", {"9", "11", "13"}),
+    "b13": ("7", {"9", "11", "b13"}),
+    "min11": ("min7", {"9", "11"}),
+    "maj13": ("maj7", {"9", "11", "13"}),
+    "min13": ("min7", {"9", "11", "13"}),
 }
 
 

--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -117,7 +117,7 @@ class InvalidChordException(Exception):
         self.message = message
         self.chord_label = chord_label
         self.name = self.__class__.__name__
-        super(InvalidChordException, self).__init__(message)
+        super().__init__(message)
 
 
 # --- Chord Primitives ---
@@ -125,14 +125,14 @@ def _pitch_classes():
     r"""Map from pitch class (str) to semitone (int)."""
     pitch_classes = ["C", "D", "E", "F", "G", "A", "B"]
     semitones = [0, 2, 4, 5, 7, 9, 11]
-    return dict([(c, s) for c, s in zip(pitch_classes, semitones)])
+    return {c: s for c, s in zip(pitch_classes, semitones)}
 
 
 def _scale_degrees():
     r"""Map scale degrees (str) to semitones (int)."""
     degrees = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13"]
     semitones = [0, 2, 4, 5, 7, 9, 11, 12, 14, 16, 17, 19, 21]
-    return dict([(d, s) for d, s in zip(degrees, semitones)])
+    return {d: s for d, s in zip(degrees, semitones)}
 
 
 # Maps pitch classes (strings) to semitone indexes (ints).
@@ -408,7 +408,7 @@ def split(chord_label, reduce_extended_chords=False):
         chord_label, scale_degrees = chord_label.split("(")
         omission = "*" in scale_degrees
         scale_degrees = scale_degrees.strip(")")
-        scale_degrees = set([i.strip() for i in scale_degrees.split(",")])
+        scale_degrees = {i.strip() for i in scale_degrees.split(",")}
 
     # Note: Chords lacking quality AND added interval information are major.
     #   If a quality shorthand is specified, it is returned.

--- a/mir_eval/display.py
+++ b/mir_eval/display.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Display functions"""
 
 from collections import defaultdict

--- a/mir_eval/display.py
+++ b/mir_eval/display.py
@@ -859,7 +859,7 @@ def separation(
     sources = np.atleast_2d(sources)
 
     if labels is None:
-        labels = ["Source {:d}".format(_) for _ in range(len(sources))]
+        labels = [f"Source {_:d}" for _ in range(len(sources))]
 
     kwargs.setdefault("scaling", "spectrum")
 
@@ -947,8 +947,8 @@ def __ticker_midi_note(x, pos):
     octave = int(x / 12) - 1
 
     if cents == 0:
-        return "{:s}{:2d}".format(NOTES[idx], octave)
-    return "{:s}{:2d}{:+02d}".format(NOTES[idx], octave, int(cents * 100))
+        return f"{NOTES[idx]:s}{octave:2d}"
+    return f"{NOTES[idx]:s}{octave:2d}{int(cents * 100):+02d}"
 
 
 def __ticker_midi_hz(x, pos):
@@ -957,7 +957,7 @@ def __ticker_midi_hz(x, pos):
     Inputs x are interpreted as midi numbers, and converted
     to Hz.
     """
-    return "{:g}".format(midi_to_hz(x))
+    return f"{midi_to_hz(x):g}"
 
 
 def ticker_notes(ax=None):

--- a/mir_eval/hierarchy.py
+++ b/mir_eval/hierarchy.py
@@ -1,5 +1,4 @@
 # CREATED:2015-09-16 14:46:47 by Brian McFee <brian.mcfee@nyu.edu>
-# -*- encoding: utf-8 -*-
 """Evaluation criteria for hierarchical structure analysis.
 
 Hierarchical structure analysis seeks to annotate a track with a nested

--- a/mir_eval/io.py
+++ b/mir_eval/io.py
@@ -27,7 +27,7 @@ def _open(file_or_str, **kwargs):
         with open(file_or_str, **kwargs) as file_desc:
             yield file_desc
     else:
-        raise IOError("Invalid file-or-str object: {}".format(file_or_str))
+        raise IOError(f"Invalid file-or-str object: {file_or_str}")
 
 
 def load_delimited(filename, converters, delimiter=r"\s+", comment="#"):
@@ -77,7 +77,7 @@ def load_delimited(filename, converters, delimiter=r"\s+", comment="#"):
     if comment is None:
         commenter = None
     else:
-        commenter = re.compile("^{}".format(comment))
+        commenter = re.compile(f"^{comment}")
 
     # Note: we do io manually here for two reasons.
     #   1. The csv module has difficulties with unicode, which may lead
@@ -524,7 +524,7 @@ def load_key(filename, delimiter=r"\s+", comment="#"):
         raise ValueError("Key file should contain only one line.")
     scale, mode = scale[0], mode[0]
     # Join with a space
-    key_string = "{} {}".format(scale, mode)
+    key_string = f"{scale} {mode}"
     # Validate them, but throw a warning in place of an error
     try:
         key.validate_key(key_string)
@@ -581,7 +581,7 @@ def load_tempo(filename, delimiter=r"\s+", comment="#"):
         warnings.warn(error.args[0])
 
     if not 0 <= weight <= 1:
-        raise ValueError("Invalid weight: {}".format(weight))
+        raise ValueError(f"Invalid weight: {weight}")
 
     return tempi, weight
 
@@ -646,7 +646,7 @@ def load_ragged_time_series(
     if comment is None:
         commenter = None
     else:
-        commenter = re.compile("^{}".format(comment))
+        commenter = re.compile(f"^{comment}")
 
     if header:
         start_row = 1

--- a/mir_eval/key.py
+++ b/mir_eval/key.py
@@ -70,7 +70,7 @@ def validate_key(key):
             )
         if mode not in ["major", "minor", "other"]:
             raise ValueError(
-                "Mode '{}' is invalid; must be 'major', 'minor' or 'other'".format(mode)
+                f"Mode '{mode}' is invalid; must be 'major', 'minor' or 'other'"
             )
 
 

--- a/mir_eval/pattern.py
+++ b/mir_eval/pattern.py
@@ -126,8 +126,8 @@ def _occurrence_intersection(occ_P, occ_Q):
         Set of the intersection between occ_P and occ_Q.
 
     """
-    set_P = set([tuple(onset_midi) for onset_midi in occ_P])
-    set_Q = set([tuple(onset_midi) for onset_midi in occ_Q])
+    set_P = {tuple(onset_midi) for onset_midi in occ_P}
+    set_Q = {tuple(onset_midi) for onset_midi in occ_Q}
     return set_P & set_Q  # Return the intersection
 
 

--- a/mir_eval/segment.py
+++ b/mir_eval/segment.py
@@ -580,7 +580,7 @@ def _adjusted_rand_index(reference_indices, estimated_indices):
     )
 
     sum_comb = sum(
-        (scipy.special.comb(n_ij, 2, exact=1) for n_ij in contingency.flatten())
+        scipy.special.comb(n_ij, 2, exact=1) for n_ij in contingency.flatten()
     )
     prod_comb = (sum_comb_c * sum_comb_k) / float(scipy.special.comb(n_samples, 2))
     mean_comb = (sum_comb_k + sum_comb_c) / 2.0

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Source separation algorithms attempt to extract recordings of individual
 sources from a recording of a mixture of sources.  Evaluation methods for

--- a/mir_eval/tempo.py
+++ b/mir_eval/tempo.py
@@ -41,7 +41,7 @@ def validate_tempi(tempi, reference=True):
         raise ValueError("tempi must have exactly two values")
 
     if not np.all(np.isfinite(tempi)) or np.any(tempi < 0):
-        raise ValueError("tempi={} must be non-negative numbers".format(tempi))
+        raise ValueError(f"tempi={tempi} must be non-negative numbers")
 
     if reference and np.all(tempi == 0):
         raise ValueError(

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -66,7 +66,7 @@ def generate_labels(items, prefix="__"):
         Synthetically generated labels
 
     """
-    return ["{}{}".format(prefix, n) for n in range(len(items))]
+    return [f"{prefix}{n}" for n in range(len(items))]
 
 
 def intervals_to_samples(intervals, labels, offset=0, sample_size=0.1, fill_value=None):

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -466,7 +466,7 @@ def intersect_files(flist1, flist2):
         """
         return os.path.splitext(os.path.split(abs_path)[-1])[0]
 
-    fmap = dict([(fname(f), f) for f in flist1])
+    fmap = {fname(f): f for f in flist1}
     pairs = [list(), list()]
     for f in flist2:
         if fname(f) in fmap:
@@ -563,7 +563,7 @@ def _bipartite_match(graph):
         # layer
         preds = {}
         unmatched = []
-        pred = dict([(u, unmatched) for u in graph])
+        pred = {u: unmatched for u in graph}
         for v in matching:
             del pred[matching[v]]
         layer = list(pred)

--- a/tests/generate_data.py
+++ b/tests/generate_data.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
     tasks["key"] = (mir_eval.key, mir_eval.io.load_key, "data/key/{}*.txt")
     # Get task keys from argv
     for task in sys.argv[1:]:
-        print("Generating data for {}".format(task))
+        print(f"Generating data for {task}")
         submodule, loader, data_glob = tasks[task]
         ref_files = sorted(glob.glob(data_glob.format("ref")))
         est_files = sorted(glob.glob(data_glob.format("est")))

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -66,7 +66,7 @@ def test_alignment_functions_fail(metric, est_alignment, pred_alignment):
 @pytest.fixture
 def alignment_data(request):
     ref_f, est_f, sco_f = request.param
-    with open(sco_f, "r") as f:
+    with open(sco_f) as f:
         expected_scores = json.load(f)
     reference_alignments = mir_eval.io.load_events(ref_f)
     estimated_alignments = mir_eval.io.load_events(est_f)

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -27,7 +27,7 @@ file_sets = list(zip(ref_files, est_files, sco_files))
 @pytest.fixture
 def beat_data(request):
     ref_f, est_f, sco_f = request.param
-    with open(sco_f, "r") as f:
+    with open(sco_f) as f:
         expected_scores = json.load(f)
     reference_beats = mir_eval.io.load_events(ref_f)
     estimated_beats = mir_eval.io.load_events(est_f)

--- a/tests/test_chord.py
+++ b/tests/test_chord.py
@@ -27,7 +27,7 @@ file_sets = list(zip(ref_files, est_files, sco_files))
 @pytest.fixture
 def chord_data(request):
     ref_f, est_f, sco_f = request.param
-    with open(sco_f, "r") as f:
+    with open(sco_f) as f:
         expected_scores = json.load(f)
     # Load in reference melody
     ref_intervals, ref_labels = mir_eval.io.load_labeled_intervals(ref_f)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -*-
 """Unit tests for the display module"""
 
 # For testing purposes, clobber the rcfile

--- a/tests/test_hierarchy.py
+++ b/tests/test_hierarchy.py
@@ -179,7 +179,7 @@ sco_files = sorted(glob.glob(SCORES_GLOB))
 def hierarchy_outcomes(request):
     sco_f = request.param
 
-    with open(sco_f, "r") as fdesc:
+    with open(sco_f) as fdesc:
         expected_scores = json.load(fdesc)
     window = float(re.match(r".*output_w=(\d+).json$", sco_f).groups()[0])
 

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -43,7 +43,7 @@ def test_key_function_fail(good_key, bad_key):
 @pytest.fixture
 def key_data(request):
     ref_f, est_f, sco_f = request.param
-    with open(sco_f, "r") as f:
+    with open(sco_f) as f:
         expected_scores = json.load(f)
     reference_key = mir_eval.io.load_key(ref_f)
     estimated_key = mir_eval.io.load_key(est_f)

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -28,7 +28,7 @@ file_sets = list(zip(ref_files, est_files, sco_files))
 @pytest.fixture
 def melody_data(request):
     ref_f, est_f, sco_f = request.param
-    with open(sco_f, "r") as f:
+    with open(sco_f) as f:
         expected_scores = json.load(f)
     # Load in reference melody
     ref_time, ref_freq = mir_eval.io.load_time_series(ref_f)

--- a/tests/test_multipitch.py
+++ b/tests/test_multipitch.py
@@ -28,7 +28,7 @@ file_sets = list(zip(ref_files, est_files, sco_files))
 def multipitch_data(request):
     ref_f, est_f, sco_f = request.param
 
-    with open(sco_f, "r") as f_handle:
+    with open(sco_f) as f_handle:
         expected_score = json.load(f_handle)
 
     ref_times, ref_freqs = mir_eval.io.load_ragged_time_series(ref_f)

--- a/tests/test_onset.py
+++ b/tests/test_onset.py
@@ -28,7 +28,7 @@ file_sets = list(zip(ref_files, est_files, sco_files))
 @pytest.fixture
 def onset_data(request):
     ref_f, est_f, sco_f = request.param
-    with open(sco_f, "r") as f:
+    with open(sco_f) as f:
         expected_scores = json.load(f)
     reference_onsets = mir_eval.io.load_events(ref_f)
     estimated_onsets = mir_eval.io.load_events(est_f)

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -27,7 +27,7 @@ file_sets = list(zip(ref_files, est_files, sco_files))
 @pytest.fixture
 def pattern_data(request):
     ref_f, est_f, sco_f = request.param
-    with open(sco_f, "r") as f:
+    with open(sco_f) as f:
         expected_scores = json.load(f)
     reference_patterns = mir_eval.io.load_patterns(ref_f)
     estimated_patterns = mir_eval.io.load_patterns(est_f)

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -27,7 +27,7 @@ file_sets = list(zip(ref_files, est_files, sco_files))
 @pytest.fixture
 def segment_data(request):
     ref_f, est_f, sco_f = request.param
-    with open(sco_f, "r") as f:
+    with open(sco_f) as f:
         expected_scores = json.load(f)
     # Load in an example segmentation annotation
     ref_intervals, ref_labels = mir_eval.io.load_labeled_intervals(ref_f)

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -30,7 +30,7 @@ file_sets = list(zip(ref_files, est_files, sco_files))
 @pytest.fixture
 def separation_data(request):
     ref_f, est_f, sco_f = request.param
-    with open(sco_f, "r") as f:
+    with open(sco_f) as f:
         expected_results = json.load(f)
         expected_sources = expected_results["Sources"]
         expected_frames = expected_results["Framewise"]

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -28,7 +28,7 @@ file_sets = list(zip(ref_files, est_files, sco_files))
 @pytest.fixture
 def tempo_data(request):
     ref_f, est_f, sco_f = request.param
-    with open(sco_f, "r") as f:
+    with open(sco_f) as f:
         expected_scores = json.load(f)
 
     def _load_tempi(filename):

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -25,7 +25,7 @@ file_sets = list(zip(ref_files, est_files, sco_files))
 @pytest.fixture
 def transcription_data(request):
     ref_f, est_f, sco_f = request.param
-    with open(sco_f, "r") as f:
+    with open(sco_f) as f:
         expected_scores = json.load(f)
     # Load in an example segmentation annotation
     ref_int, ref_pitch = mir_eval.io.load_valued_intervals(ref_f)

--- a/tests/test_transcription_velocity.py
+++ b/tests/test_transcription_velocity.py
@@ -35,7 +35,7 @@ def _load_transcription_velocity(filename):
 @pytest.fixture
 def velocity_data(request):
     ref_f, est_f, sco_f = request.param
-    with open(sco_f, "r") as f:
+    with open(sco_f) as f:
         expected_scores = json.load(f)
     # Load in reference transcription
     ref_int, ref_pitch, ref_vel = _load_transcription_velocity(ref_f)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -165,8 +165,8 @@ def test_bipartite_match():
     assert len(matching) == len(u_set)
 
     # Make sure that there are no duplicate keys
-    lhs = set([k for k in matching])
-    rhs = set([matching[k] for k in matching])
+    lhs = {k for k in matching}
+    rhs = {matching[k] for k in matching}
 
     assert len(matching) == len(lhs)
     assert len(matching) == len(rhs)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -153,8 +153,8 @@ def test_bipartite_match():
     #
     G = collections.defaultdict(list)
 
-    u_set = ["u{:d}".format(_) for _ in range(10)]
-    v_set = ["v{:d}".format(_) for _ in range(len(u_set) + 1)]
+    u_set = [f"u{_:d}" for _ in range(10)]
+    v_set = [f"v{_:d}" for _ in range(len(u_set) + 1)]
     for i, u in enumerate(u_set):
         for v in v_set[: -i - 1]:
             G[v].append(u)


### PR DESCRIPTION
Very minor nitpicks but perhaps nice to keep the syntax fresh since Python 3.8 is now the latest non-EOL version.

1. Drop utf-8 encoding header
1. Use f-strings
1. Use set comprehension, set literals, dict comprehensions, instead of converting lists

Nothing major and not urgent to fix. Arguably not worth merging in case this breaks unexpected monkey patches in the wild. This is just me sitting at an airport with a coffee and reading the source.